### PR TITLE
Determine cost for Basic, TOU, and Peak Demand plans

### DIFF
--- a/src/tep_usage_analysis/commons.py
+++ b/src/tep_usage_analysis/commons.py
@@ -1,0 +1,6 @@
+def tier_dict(low: float, med: float, high: float) -> dict[str, float]:
+    return {
+        "<=500": low,
+        "500-1000": med,
+        ">1000": high,
+    }

--- a/src/tep_usage_analysis/cost_estimate.py
+++ b/src/tep_usage_analysis/cost_estimate.py
@@ -108,12 +108,22 @@ def peak_demand(input_df: pd.DataFrame):
 
     arrays = dict_commons(input_df)
 
-    print(peak_sum(arrays["summer_df"], "summer"))
-    print(peak_sum(arrays["winter_df"], "winter"))
-    demand = input_df[arrays["peak_index"]]["USAGE"].max()
+    summer_energy_charge = peak_sum(arrays["summer_df"], "summer")
+    winter_energy_charge = peak_sum(arrays["winter_df"], "winter")
+    demand = input_df[
+        arrays["peak_summer_index"] | arrays["peak_winter_index"]
+    ]["USAGE"].max()
     demand_charge = demand * (
         PEAK_DEMAND_RATES["<=7"] if demand <= 7 else PEAK_DEMAND_RATES[">7"])
-    print(demand, demand_charge)
+
+    print(
+        f"Summer Energy Charge: ${summer_energy_charge:6.2f}\n"
+        f"Winter Energy Charge: ${winter_energy_charge:6.2f}\n"
+        f"Peak demand: {demand} kW\n"
+    )
+
+    usage = summer_energy_charge + winter_energy_charge + demand_charge
+    print(f"Estimate cost with Peak Demand plan: ${usage:6.2f}")
 
 
 def peak_sum(t_df: pd.DataFrame, period: str):

--- a/src/tep_usage_analysis/cost_estimate.py
+++ b/src/tep_usage_analysis/cost_estimate.py
@@ -57,6 +57,11 @@ def df_sum(i_df: pd.DataFrame):
     return i_df["USAGE"].sum()
 
 
+def get_weekdays(input_df: pd.DataFrame):
+    """Obtain weekday records"""
+    return pd.DatetimeIndex(input_df["DATE"]).weekday < 4
+
+
 def peak_demand(input_df: pd.DataFrame):
     """Compute usage based on Peak Demand plan"""
 
@@ -69,7 +74,8 @@ def peak_demand(input_df: pd.DataFrame):
     ).hour
 
     summer_index = (month <= 9) & (month >= 5)
-    peak_index = (start_hour >= 3) & (start_hour <= 6)
+    weekdays = get_weekdays(input_df)
+    peak_index = (start_hour >= 3) & (start_hour <= 6) & weekdays
 
     summer_df = input_df[summer_index]
     winter_df = input_df[~summer_index]
@@ -112,7 +118,8 @@ def tou(input_df: pd.DataFrame):
     ).hour
 
     summer_index = (month <= 9) & (month >= 5)
-    peak_index = (start_hour >= 3) & (start_hour <= 6)
+    weekdays = get_weekdays(input_df)
+    peak_index = (start_hour >= 3) & (start_hour <= 6) & weekdays
 
     summer_on_df = input_df[summer_index & peak_index]
     summer_off_df = input_df[summer_index & (~peak_index)]

--- a/src/tep_usage_analysis/cost_estimate.py
+++ b/src/tep_usage_analysis/cost_estimate.py
@@ -1,0 +1,92 @@
+import pandas as pd
+from rich import print
+
+from .commons import tier_dict
+BASIC_RATES = {
+    "summer": tier_dict(0.1081, 0.1254, 0.1317),
+    "winter": tier_dict(0.1052, 0.1224, 0.1287),
+}
+
+TOU_ON_RATES = {
+    "summer": tier_dict(0.1416, 0.1528, 0.1592),
+    "winter": tier_dict(0.1112, 0.1225, 0.1288),
+}
+
+TOU_OFF_RATES = {
+    "summer": tier_dict(0.1056, 0.1169, 0.1232),
+    "winter": tier_dict(0.1050, 0.1163, 0.1226),
+}
+
+
+def basic(input_df: pd.DataFrame):
+    """Compute usage based on Basic plan"""
+
+    total_usage = df_sum(input_df)
+    print(f"Total usage: {total_usage} kWh")
+
+    month = pd.DatetimeIndex(input_df["DATE"]).month
+    summer_index = (month <= 9) & (month >= 5)
+    summer_df = input_df[summer_index]
+    winter_df = input_df[~summer_index]
+
+    usage = tier_sum(summer_df, BASIC_RATES, "summer")
+    usage += tier_sum(winter_df, BASIC_RATES, "winter")
+
+    print(f"Estimate cost with Basic plan: ${usage:6.2f}")
+
+
+def df_sum(i_df: pd.DataFrame):
+    """Total usage in kWh"""
+    return i_df["USAGE"].sum()
+
+
+def tier_sum(t_df: pd.DataFrame, rates: dict, period: str):
+    """Compute sum for summer/winter month using 3-level tiers"""
+    _total = df_sum(t_df)
+
+    _usage = min([_total, 500]) * rates[period]["<=500"]
+    if _total >= 500:
+        _usage += min([_total-500, 500]) * rates[period]["500-1000"]
+    if _total >= 1000:
+        _usage += (_total-1000) * rates[period][">1000"]
+    return _usage
+
+
+def tou(input_df: pd.DataFrame):
+    """Compute usage based on Time-of-Use (TOU) plan"""
+
+    total_usage = df_sum(input_df)
+    print(f"Total usage: {total_usage} kWh")
+
+    month = pd.DatetimeIndex(input_df["DATE"]).month
+    start_hour = pd.DatetimeIndex(
+        pd.to_datetime(input_df["START TIME"], format="%H:%M")
+    ).hour
+
+    summer_index = (month <= 9) & (month >= 5)
+    peak_index = (start_hour >= 3) & (start_hour <= 6)
+
+    summer_on_df = input_df[summer_index & peak_index]
+    summer_off_df = input_df[summer_index & (~peak_index)]
+
+    winter_on_df = input_df[(~summer_index) & peak_index]
+    winter_off_df = input_df[(~summer_index) & (~peak_index)]
+
+    s_on = tier_sum(summer_on_df, TOU_ON_RATES, "summer")
+    s_off = tier_sum(summer_off_df, TOU_OFF_RATES, "summer")
+    w_on = tier_sum(winter_on_df, TOU_ON_RATES, "winter")
+    w_off = tier_sum(winter_off_df, TOU_OFF_RATES, "winter")
+
+    print(
+        f"Summer peak: {df_sum(summer_on_df):7.2f} kWh "
+        f"({len(summer_on_df):3} hrs)  ${s_on:6.2f}\n"
+        f"Summer off:  {df_sum(summer_off_df):7.2f} kWh "
+        f"({len(summer_off_df):3} hrs)  ${s_off:6.2f}\n"
+        f"Winter peak: {df_sum(winter_on_df):7.2f} kWh "
+        f"({len(winter_on_df):3} hrs)  ${w_on:6.2f}\n"
+        f"Winter off:  {df_sum(winter_off_df):7.2f} kWh "
+        f"({len(winter_off_df):3} hrs)  ${w_off:6.2f}\n"
+    )
+
+    usage = s_on + s_off + w_on + w_off
+    print(f"Estimate cost with TOU plan: ${usage:6.2f}")

--- a/src/tep_usage_analysis/cost_estimate.py
+++ b/src/tep_usage_analysis/cost_estimate.py
@@ -31,7 +31,7 @@ TOU_OFF_RATES = {
 CALENDAR = USFederalHolidayCalendar()
 
 
-def basic(input_df: pd.DataFrame):
+def basic(input_df: pd.DataFrame) -> float:
     """Compute usage based on Basic plan"""
 
     arrays = dict_commons(input_df)
@@ -50,6 +50,8 @@ def basic(input_df: pd.DataFrame):
     )
 
     print(f"Estimate cost with Basic plan: ${usage:6.2f}")
+
+    return usage
 
 
 def dict_commons(input_df: pd.DataFrame) -> dict:
@@ -103,7 +105,7 @@ def get_weekdays(input_df: pd.DataFrame):
     return pd.DatetimeIndex(input_df["DATE"]).weekday < 4
 
 
-def peak_demand(input_df: pd.DataFrame):
+def peak_demand(input_df: pd.DataFrame) -> float:
     """Compute usage based on Peak Demand plan"""
 
     arrays = dict_commons(input_df)
@@ -125,6 +127,8 @@ def peak_demand(input_df: pd.DataFrame):
     usage = summer_energy_charge + winter_energy_charge + demand_charge
     print(f"Estimate cost with Peak Demand plan: ${usage:6.2f}")
 
+    return usage
+
 
 def peak_sum(t_df: pd.DataFrame, period: str):
     _total = df_sum(t_df)
@@ -144,7 +148,7 @@ def tier_sum(t_df: pd.DataFrame, rates: dict, period: str) -> list:
     return tier_usage
 
 
-def tou(input_df: pd.DataFrame):
+def tou(input_df: pd.DataFrame) -> float:
     """Compute usage based on Time-of-Use (TOU) plan"""
 
     arrays = dict_commons(input_df)
@@ -181,3 +185,4 @@ def tou(input_df: pd.DataFrame):
 
     usage = sum(s_on_tier + s_off_tier + w_on_tier + w_off_tier)
     print(f"Estimate cost with TOU plan: ${usage:6.2f}")
+    return usage

--- a/src/tep_usage_analysis/cost_estimate.py
+++ b/src/tep_usage_analysis/cost_estimate.py
@@ -66,7 +66,7 @@ def dict_commons(input_df: pd.DataFrame) -> dict:
     summer_index = (month <= 9) & (month >= 5)
     weekdays = get_weekdays(input_df)
     holidays = get_holidays(input_df)
-    peak_index = (start_hour >= 3) & (start_hour <= 6) & weekdays & (~holidays)
+    peak_index = (start_hour >= 15) & (start_hour <= 18) & weekdays & (~holidays)
     summer_df = input_df[summer_index]
     winter_df = input_df[~summer_index]
 

--- a/src/tep_usage_analysis/cost_estimate.py
+++ b/src/tep_usage_analysis/cost_estimate.py
@@ -2,9 +2,17 @@ import pandas as pd
 from rich import print
 
 from .commons import tier_dict
+
 BASIC_RATES = {
     "summer": tier_dict(0.1081, 0.1254, 0.1317),
     "winter": tier_dict(0.1052, 0.1224, 0.1287),
+}
+
+PEAK_DEMAND_RATES = {
+    "summer": 0.0711,
+    "winter": 0.0681,
+    "<=7": 10.18,
+    ">7": 14.79,
 }
 
 TOU_ON_RATES = {
@@ -15,13 +23,6 @@ TOU_ON_RATES = {
 TOU_OFF_RATES = {
     "summer": tier_dict(0.1056, 0.1169, 0.1232),
     "winter": tier_dict(0.1050, 0.1163, 0.1226),
-}
-
-PEAK_DEMAND_RATES = {
-    "summer": 0.0711,
-    "winter": 0.0681,
-    "<=7": 10.18,
-    ">7": 14.79,
 }
 
 

--- a/src/tep_usage_analysis/cost_estimate.py
+++ b/src/tep_usage_analysis/cost_estimate.py
@@ -29,8 +29,18 @@ def basic(input_df: pd.DataFrame):
     summer_df = input_df[summer_index]
     winter_df = input_df[~summer_index]
 
-    usage = tier_sum(summer_df, BASIC_RATES, "summer")
-    usage += tier_sum(winter_df, BASIC_RATES, "winter")
+    summer_tier = tier_sum(summer_df, BASIC_RATES, "summer")
+    winter_tier = tier_sum(winter_df, BASIC_RATES, "winter")
+
+    usage = sum(summer_tier + winter_tier)
+
+    print(
+        f"Tier         | Summer  | Winter  |\n"
+        f"-------------|---------|---------|\n"
+        f"<=500 kWh    | ${summer_tier[0]:6.2f} | ${winter_tier[0]:6.2f} |\n"
+        f"500-1000 kWh | ${summer_tier[1]:6.2f} | ${winter_tier[1]:6.2f} |\n"
+        f">1000 kWh    | ${summer_tier[2]:6.2f} | ${winter_tier[2]:6.2f} |\n"
+    )
 
     print(f"Estimate cost with Basic plan: ${usage:6.2f}")
 
@@ -40,16 +50,16 @@ def df_sum(i_df: pd.DataFrame):
     return i_df["USAGE"].sum()
 
 
-def tier_sum(t_df: pd.DataFrame, rates: dict, period: str):
+def tier_sum(t_df: pd.DataFrame, rates: dict, period: str) -> list:
     """Compute sum for summer/winter month using 3-level tiers"""
     _total = df_sum(t_df)
 
-    _usage = min([_total, 500]) * rates[period]["<=500"]
+    tier_usage = [min([_total, 500]) * rates[period]["<=500"], 0, 0]
     if _total >= 500:
-        _usage += min([_total-500, 500]) * rates[period]["500-1000"]
+        tier_usage[1] = min([_total-500, 500]) * rates[period]["500-1000"]
     if _total >= 1000:
-        _usage += (_total-1000) * rates[period][">1000"]
-    return _usage
+        tier_usage[2] = (_total-1000) * rates[period][">1000"]
+    return tier_usage
 
 
 def tou(input_df: pd.DataFrame):
@@ -72,21 +82,21 @@ def tou(input_df: pd.DataFrame):
     winter_on_df = input_df[(~summer_index) & peak_index]
     winter_off_df = input_df[(~summer_index) & (~peak_index)]
 
-    s_on = tier_sum(summer_on_df, TOU_ON_RATES, "summer")
-    s_off = tier_sum(summer_off_df, TOU_OFF_RATES, "summer")
-    w_on = tier_sum(winter_on_df, TOU_ON_RATES, "winter")
-    w_off = tier_sum(winter_off_df, TOU_OFF_RATES, "winter")
+    s_on_tier = tier_sum(summer_on_df, TOU_ON_RATES, "summer")
+    s_off_tier = tier_sum(summer_off_df, TOU_OFF_RATES, "summer")
+    w_on_tier = tier_sum(winter_on_df, TOU_ON_RATES, "winter")
+    w_off_tier = tier_sum(winter_off_df, TOU_OFF_RATES, "winter")
 
     print(
         f"Summer peak: {df_sum(summer_on_df):7.2f} kWh "
-        f"({len(summer_on_df):3} hrs)  ${s_on:6.2f}\n"
+        f"({len(summer_on_df):3} hrs)  ${sum(s_on_tier):6.2f}\n"
         f"Summer off:  {df_sum(summer_off_df):7.2f} kWh "
-        f"({len(summer_off_df):3} hrs)  ${s_off:6.2f}\n"
+        f"({len(summer_off_df):3} hrs)  ${sum(s_off_tier):6.2f}\n"
         f"Winter peak: {df_sum(winter_on_df):7.2f} kWh "
-        f"({len(winter_on_df):3} hrs)  ${w_on:6.2f}\n"
+        f"({len(winter_on_df):3} hrs)  ${sum(w_on_tier):6.2f}\n"
         f"Winter off:  {df_sum(winter_off_df):7.2f} kWh "
-        f"({len(winter_off_df):3} hrs)  ${w_off:6.2f}\n"
+        f"({len(winter_off_df):3} hrs)  ${sum(w_off_tier):6.2f}\n"
     )
 
-    usage = s_on + s_off + w_on + w_off
+    usage = sum(s_on_tier + s_off_tier + w_on_tier + w_off_tier)
     print(f"Estimate cost with TOU plan: ${usage:6.2f}")

--- a/src/tep_usage_analysis/cost_estimate.py
+++ b/src/tep_usage_analysis/cost_estimate.py
@@ -66,7 +66,8 @@ def dict_commons(input_df: pd.DataFrame) -> dict:
     summer_index = (month <= 9) & (month >= 5)
     weekdays = get_weekdays(input_df)
     holidays = get_holidays(input_df)
-    peak_index = (start_hour >= 15) & (start_hour <= 18) & weekdays & (~holidays)
+    peak_summer_index = (start_hour >= 15) & (start_hour <= 18) & weekdays & (~holidays)
+    peak_winter_index = (((start_hour >= 6) & (start_hour <= 8)) | (start_hour >= 18) & (start_hour <= 20)) & weekdays & (~holidays)
     summer_df = input_df[summer_index]
     winter_df = input_df[~summer_index]
 
@@ -74,7 +75,8 @@ def dict_commons(input_df: pd.DataFrame) -> dict:
         "total_usage": total_usage,
         "month": month,
         "summer_index": summer_index,
-        "peak_index": peak_index,
+        "peak_summer_index": peak_summer_index,
+        "peak_winter_index": peak_winter_index,
         "summer_df": summer_df,
         "winter_df": winter_df
     }
@@ -137,11 +139,19 @@ def tou(input_df: pd.DataFrame):
 
     arrays = dict_commons(input_df)
 
-    summer_on_df = input_df[arrays["summer_index"] & arrays["peak_index"]]
-    summer_off_df = input_df[arrays["summer_index"] & (~arrays["peak_index"])]
+    summer_on_df = input_df[
+        arrays["summer_index"] & arrays["peak_summer_index"]
+    ]
+    summer_off_df = input_df[
+        arrays["summer_index"] & (~arrays["peak_summer_index"])
+    ]
 
-    winter_on_df = input_df[(~arrays["summer_index"]) & arrays["peak_index"]]
-    winter_off_df = input_df[(~arrays["summer_index"]) & (~arrays["peak_index"])]
+    winter_on_df = input_df[
+        (~arrays["summer_index"]) & arrays["peak_winter_index"]
+    ]
+    winter_off_df = input_df[
+        (~arrays["summer_index"]) & (~arrays["peak_winter_index"])
+    ]
 
     s_on_tier = tier_sum(summer_on_df, TOU_ON_RATES, "summer")
     s_off_tier = tier_sum(summer_off_df, TOU_OFF_RATES, "summer")


### PR DESCRIPTION
Closes #4

- Compute basic and tou usage cost #4
- Simplify tier_sum() and provide more info in print statements
- Estimate peak demand plan with peak_demand
- Add get_weekdays function
- Resort constants
- Refactor with dict_commons
- Identify major holidays according to U.S. fed
- Fix bug with peak_index
- Compute peak winter index accordingly
- Adjust peak_demand for better print messaging
